### PR TITLE
Rename to calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# arithimetic
+# Calculator
 
-四則演算を行う実行可能プログラム
+Haskellで電卓を実装してみた
 
 ## 実行方法
 

--- a/calculator.cabal
+++ b/calculator.cabal
@@ -4,13 +4,13 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: dafab84516dd08849def1c93f065045d6ae449ec13b93fbf806d7930dbabd51d
+-- hash: ee715cebd35942e9dff28bd7791a38fd5eab2ed5cd3cbe5c205ce091eb360ff5
 
-name:           arithimetic
+name:           calculator
 version:        0.1.0.0
-description:    Please see the README on GitHub at <https://github.com/githubuser/arithimetic#readme>
-homepage:       https://github.com/githubuser/arithimetic#readme
-bug-reports:    https://github.com/githubuser/arithimetic/issues
+description:    Please see the README on GitHub at <https://github.com/githubuser/calculator#readme>
+homepage:       https://github.com/HirotoShioi/calculator#readme
+bug-reports:    https://github.com/HirotoShioi/calculator/issues
 author:         Author name here
 maintainer:     example@example.com
 copyright:      2020 Author name here
@@ -23,7 +23,7 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: https://github.com/githubuser/arithimetic
+  location: https://github.com/HirotoShioi/calculator
 
 library
   exposed-modules:
@@ -32,7 +32,7 @@ library
       RPN
       ShuntingYard
   other-modules:
-      Paths_arithimetic
+      Paths_calculator
   hs-source-dirs:
       src
   ghc-options: -Werror -Wall
@@ -45,35 +45,35 @@ library
     , parsec
   default-language: Haskell2010
 
-executable arithimetic-exe
+executable calculator-exe
   main-is: Main.hs
   other-modules:
-      Paths_arithimetic
+      Paths_calculator
   hs-source-dirs:
       app
   ghc-options: -Werror -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       QuickCheck
-    , arithimetic
     , base >=4.7 && <5
+    , calculator
     , containers
     , hspec
     , mtl
     , parsec
   default-language: Haskell2010
 
-test-suite arithimetic-test
+test-suite calculator-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
-      Paths_arithimetic
+      Paths_calculator
   hs-source-dirs:
       test
   ghc-options: -Werror -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       QuickCheck
-    , arithimetic
     , base >=4.7 && <5
+    , calculator
     , containers
     , hspec
     , mtl

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
-name:                arithimetic
+name:                calculator
 version:             0.1.0.0
-github:              "githubuser/arithimetic"
+github:              "HirotoShioi/calculator"
 license:             BSD3
 author:              "Author name here"
 maintainer:          "example@example.com"
@@ -17,7 +17,7 @@ extra-source-files:
 # To avoid duplicated efforts in documentation and dealing with the
 # complications of embedding Haddock markup inside cabal files, it is
 # common to point users to the README.md file.
-description:         Please see the README on GitHub at <https://github.com/githubuser/arithimetic#readme>
+description:         Please see the README on GitHub at <https://github.com/githubuser/calculator#readme>
 
 dependencies:
 - base >= 4.7 && < 5
@@ -36,7 +36,7 @@ library:
     - -Wall
 
 executables:
-  arithimetic-exe:
+  calculator-exe:
     main:                Main.hs
     source-dirs:         app
     ghc-options:
@@ -44,10 +44,10 @@ executables:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - arithimetic
+    - calculator
 
 tests:
-  arithimetic-test:
+  calculator-test:
     main:                Spec.hs
     source-dirs:         test
     ghc-options:
@@ -55,4 +55,4 @@ tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - arithimetic
+    - calculator


### PR DESCRIPTION
パッケージ名をcalculatorに変更した。元々`arithimetic`という名前だったが、電卓のほうが適切であったため。